### PR TITLE
Add example .env file for client

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+JWT_SECRET="put_the_same_jwt_secret_as_in_server_applications_properties"
+NEXT_PUBLIC_API_URL="url_of_your_server_api"

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -31,7 +31,8 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+.env.local
 
 # vercel
 .vercel


### PR DESCRIPTION
## Motivation and Context

Add an example .env file for easier configuration of the client.

## Description

By adapting the .gitignore of the client it is now possible to add an .env.example file inside the .client directory which shows the environment-variables which one has to set.

## Steps for Testing

No testing necessary.

## Review Progress

- [ ] Affects API
- [ ] Tests added/updated
- [ ] Documentation updated