### PR TITLE
Fix/gitleaks history

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,4 +1,2 @@
-266f924
-ea2e93e
-bfa1787
-6cdcd0f
+acf85a2c8fb6870ff4300835b1b671720e843576:.github/workflows/client_ci.yml:generic-api-key:90
+acf85a2c8fb6870ff4300835b1b671720e843576:.github/workflows/client_ci.yml:generic-api-key:92


### PR DESCRIPTION
This pull request updates the `.gitleaksignore` file to include additional entries for ignoring specific secrets detected in the `.github/workflows/client_ci.yml` file.

* [`.gitleaksignore`](diffhunk://#diff-923efe99d6c7d5214835596b604a975bd0cdb77a0407b214ea308a97ea7b55dbR1-R2): Added two entries to ignore potential generic API keys found on lines 90 and 92 of `.github/workflows/client_ci.yml`.