### PR TITLE
Update workflow condition to trigger on manual dispatch

### DIFF
--- a/.github/workflows/deployAWS_docker.yml
+++ b/.github/workflows/deployAWS_docker.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: AWS_EC2
       url: "https://client.${{ vars.EC2_PUBLIC_IP }}.nip.io"


### PR DESCRIPTION
This pull request updates the deployment workflow configuration to enhance flexibility in triggering deployments. The key change allows the workflow to be triggered either manually via `workflow_dispatch` or automatically upon the successful conclusion of another workflow.

### Workflow configuration updates:

* [`.github/workflows/deployAWS_docker.yml`](diffhunk://#diff-03d53aa0b29bd0a5cc73481c1b0756c5e3fb449f27aa764f94421515472fd4c6L13-R13): Modified the `if` condition to allow the workflow to run if triggered manually (`workflow_dispatch`) or if the `workflow_run` event concludes successfully.